### PR TITLE
Include GeoJSON properties on features

### DIFF
--- a/src/leaflet.geojson.encoded.js
+++ b/src/leaflet.geojson.encoded.js
@@ -93,6 +93,9 @@ L.GeoJSON.Encoded = L.GeoJSON.extend({
 				feature = this._decodeFeature(features[i]);
 
 				if (feature.geometries || feature.geometry || feature.features || feature.coordinates) {
+					if(features[i].properties){
+						feature.properties = features[i].properties;
+					}
 					this.addData(feature);
 				}
 			}


### PR DESCRIPTION
On master, properties present in the GeoJSON object are not copied over to the feature upon creation. This PR restores this functionality, and is consistent with the behavior of the parent class L.GeoJSON.
